### PR TITLE
Potential fix for code scanning alert no. 5: Use of insecure SSL/TLS version

### DIFF
--- a/instagram-to-wordpress/oauth_server_instagram.py
+++ b/instagram-to-wordpress/oauth_server_instagram.py
@@ -59,6 +59,7 @@ class OAuthServer:
                 self._my_server = socketserver.TCPServer(
                     ("0.0.0.0", self.PORT), SimpleHttpServer)
                 ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
                 ssl_context.load_cert_chain(
                     "./cert.pem", "./key.pem", password=os.environ['SSL_PASSWORD'])
                 self._my_server.socket = ssl_context.wrap_socket(


### PR DESCRIPTION
Potential fix for [https://github.com/cristiadu/scripts/security/code-scanning/5](https://github.com/cristiadu/scripts/security/code-scanning/5)

To fix the issue, we will explicitly set the minimum TLS version for the `ssl.SSLContext` object to `ssl.TLSVersion.TLSv1_2`. This ensures that only TLS 1.2 or higher is allowed, regardless of the system's default configuration. The `minimum_version` attribute of the `ssl.SSLContext` object, introduced in Python 3.7, will be used for this purpose.

The changes will be made in the `start_oauth_server` method of the `OAuthServer` class, where the `ssl.SSLContext` object is created. Specifically:
1. Add a line to set `ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2` immediately after the `ssl.SSLContext` object is created.
2. Ensure no other changes are made to the functionality of the server.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
